### PR TITLE
 Add startMonitoring call to README under block based reachability call

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ NSDictionary *parameters = @{@"foo": @"bar", @"baz": @[@1, @2, @3]};
 [[AFNetworkReachabilityManager sharedManager] setReachabilityStatusChangeBlock:^(AFNetworkReachabilityStatus status) {
     NSLog(@"Reachability: %@", AFStringFromNetworkReachabilityStatus(status));
 }];
+
+[[AFNetworkReachabilityManager sharedManager] startMonitoring];
 ```
 
 #### HTTP Manager Reachability


### PR DESCRIPTION
 Add startMonitoring call to README to clarify that startMonitoring still need to be called when using the block based reachability callback method
